### PR TITLE
[FEATURE] Add TYPO3 extension-key to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,5 +11,10 @@
     "psr-4": {
       "B13\\Warmup\\": "Classes/"
     }
+  },
+  "extra": {
+    "typo3/cms": {
+      "extension-key": "warmup"
+    }
   }
 }


### PR DESCRIPTION
Documentation: https://docs.typo3.org/m/typo3/reference-coreapi/master/en-us/ExtensionArchitecture/ComposerJson/Index.html#extra