### PR TITLE
[BUGFIX] Add missing 'RootlineUtility::get()' call

### DIFF
--- a/Classes/Service/RootlineWarmupService.php
+++ b/Classes/Service/RootlineWarmupService.php
@@ -48,7 +48,6 @@ class RootlineWarmupService
         if ($pageRecord['sys_language_uid']) {
             $context->setAspect('language', new LanguageAspect($pageRecord['sys_language_uid']));
         }
-        GeneralUtility::makeInstance(RootlineUtility::class, $pageRecord['uid'], '', $context);
-
+        GeneralUtility::makeInstance(RootlineUtility::class, $pageRecord['uid'], '', $context)->get();
     }
 }


### PR DESCRIPTION
`RootlineWarmupService()` creates the instance of the Typo3
RootlineUtility without calling method `get()`. Thus rootline
caches will not be created, and traversing the page tree is a
waste of time in this case.

`RootlineV8Service` calls this method on the RootlineUtility
properly.

This change simply adds the missing method call.